### PR TITLE
Update K8s resource API version

### DIFF
--- a/deploy/deploy/overlays/app/deployment.yaml
+++ b/deploy/deploy/overlays/app/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello2
@@ -9,11 +9,11 @@ spec:
       template:
         spec:
           containers:
-          - name: hello2
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
+            - name: hello2
+              image: busybox:1.28
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure


### PR DESCRIPTION
This pull request updates the API version from `batch/v1beta1` to `batch/v1` for `CronJob` in `cron2`