### PR TITLE
OPERATION-575 Update K8s resource API version

### DIFF
--- a/deploy/deploy/overlays/app/deployment.yaml
+++ b/deploy/deploy/overlays/app/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello2


### PR DESCRIPTION
This pull request updates the API version from `batch/v1beta1` to `batch/v1` for `CronJob`